### PR TITLE
Scape mini minor tweaks

### DIFF
--- a/mini/scape/sql.py
+++ b/mini/scape/sql.py
@@ -131,10 +131,10 @@ def _condition_to_where(condition):
         value = '({} {} "{}")'.format(lhs, operator, rhs)
 
     elif isinstance(condition, scape.registry.Or):
-        value = _paren([_condition_to_where(x) for x in condition.xs], 'OR')
+        value = _paren([_condition_to_where(x) for x in condition.parts], 'OR')
 
     elif isinstance(condition, scape.registry.And):
-        value = _paren([_condition_to_where(x) for x in condition.xs], 'AND')
+        value = _paren([_condition_to_where(x) for x in condition.parts], 'AND')
 
     return value
 
@@ -187,7 +187,7 @@ class SqlDataSource(scape.registry.DataSource):
 
     def _get_field_names(self, select):
         names = set()
-        for selector in select._fields:
+        for selector in select.fields:
             names.update(f.name for f in self._metadata.fields_matching(selector))
             _log.debug(names)
         return sorted(names)
@@ -205,7 +205,7 @@ class SqlDataSource(scape.registry.DataSource):
           sqlalchemy.sql.elements.TextClause: text clause for this Select
 
         '''
-        condition = self._rewrite(select._condition)
+        condition = self._rewrite(select.condition)
         where_clause = _condition_to_where(condition)
         fields = self._get_field_names(select)
         # XXXX FIX!!!! XXXX


### PR DESCRIPTION
A few changes to code structure in scape.registry:
- Moved Registry class definition to bottom of module (since it depends on everything else
## Condition objects
- Now have copy method
- New class `ConstituentCondition` from which `And` and `Or` subclass 
- Naming tweak: instead of `xs` for constituents of `And`/`Or`, I'm calling them `parts`
- `And` and `Or` get 100% of their functionality from `ConstituentCondition` parent class. Can be overridden, but they're essentially clones right now
- `BinaryCondition` now encodes 100% of functionality for `Equals`, `MatchesCond`, `GreaterThan`, `GreaterThanEqualTo`
## Select object

A few major changes to the Select object, a few minor tweaks.
### Major Changes

I have pretty strong opinions about these changes. 
- First and foremost: I got rid of the setting attributes (via `setattr`) for Select objects based on non-specified keyword arguments (i.e. `**kwargs`) in the constructor. 
  - This is most definitely an anti-pattern in Python
  - It's a recipe for debugging hell 
  - I'm making the assumption that this was implemented for use by future `DataSource` subclasses for storing `DataSource`-specific selection arguments
  - I added a specific property for accessing these attributes (`ds_args`). It even behaves like a proper namespace and is immutable
- Second, I added public `@property` descriptors for the `_fields` and `_condition` attributes
  - It seems to me that a Select object makes no sense without fields and conditions, at least not in context of Scape. These are intrinsic, therefore it makes sense to make them available for public introspection
  - Both of these are used extensively by the rest of the codebase as _de facto_ public attributes
  - The `@property` descriptors do not expose the actual references; they expose copies, so the underlying implementation remained protected
- These changes have been propagated out to other modules/tests such that all existing unit tests pass.
## DataSource objects
- Naming tweaks
- Minor refactors 
